### PR TITLE
Allow `#[patchable]` on generic field types

### DIFF
--- a/patchable/src/lib.rs
+++ b/patchable/src/lib.rs
@@ -249,6 +249,32 @@ pub(crate) mod test {
         assert_eq!(s, UnitStruct);
     }
 
+    #[derive(Clone, Debug, Serialize, Deserialize, Patchable, PartialEq)]
+    struct Wrapper<T> {
+        value: T,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize, Patchable, PartialEq)]
+    struct Holder<T> {
+        #[patchable]
+        inner: Wrapper<T>,
+    }
+
+    #[test]
+    fn test_patchable_generic_field_type() -> anyhow::Result<()> {
+        let holder = Holder {
+            inner: Wrapper { value: 7u32 },
+        };
+        let mut target = holder.clone();
+
+        let state: String = serde_json::to_string(&holder)?;
+        let patch = serde_json::from_str(&state)?;
+
+        target.patch(patch);
+        assert_eq!(target, holder);
+        Ok(())
+    }
+
     #[derive(Debug, PartialEq)]
     struct FallibleStruct {
         value: i32,


### PR DESCRIPTION
### Motivation
- The derive macro previously required `#[patchable]` fields to be simple concrete types and failed for generic wrapper types, preventing deriving `Patchable` when a field uses a type parameter.
- The change aims to support `#[patchable]` on fields whose types refer to generic parameters so generated state types and bounds are correct.

### Description
- Track patchable field types separately as `patchable_field_types` and replace the previous `TypeUsage` enum with a compact `TypeUsage { used_in_keep: bool }` to mark types referenced from kept fields.
- Add `collect_patchable_generic_params` and `is_generic_param_type` helpers to detect generic parameters used by `#[patchable]` fields and include them in the generated state generics and bounds.
- Generate patch field types using qualified projections for concrete patchable types (`<#ty as crate::Patchable>::Patch`) while emitting `T::Patch` for plain generic parameters, and add `Patchable` bounds for concrete field types.
- Added a regression test in `patchable/src/lib.rs` that verifies `#[patchable]` works for a field with a generic wrapper type and ensured serde-compatible bounds are emitted as needed.

### Testing
- Ran `cargo test` which compiled the procedural macro and library and executed unit tests; all tests passed (`6 passed` unit tests, plus doctests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778002de9c8326bfd8a8097e633fcf)