### PR TITLE
refactor: Decouple patch definition from application logic

### DIFF
--- a/patchable-macro/Cargo.toml
+++ b/patchable-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "patchable-macro"
-description = "Macros 1.1 implementation of #[derive(Patchable)] for the patchable crate"
+description = "Derive macros for traits Patchable and Patch in the patchable crate"
 version.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/patchable-macro/src/context.rs
+++ b/patchable-macro/src/context.rs
@@ -1,11 +1,11 @@
 //! # Macro Context
 //!
-//! Context and logic for the `Patchable` derive macro.
+//! [`MacroContext::new`] parses the derive input and normalizes it into a
+//! [`MacroContext`] that drives code generation.
 //!
-//! This module contains the [`MacroContext`] struct, which analyzes the input struct and generates
-//! the code for:
-//! 1. The companion patch struct (state struct).
-//! 2. The `Patchable` trait implementation.
+//! The context records field actions, preserved generics, and crate paths so the
+//! macro can emit the companion patch struct plus the `Patchable` and `Patch`
+//! trait implementations.
 
 use std::collections::HashMap;
 
@@ -26,7 +26,7 @@ enum TypeUsage {
 }
 
 pub(crate) struct MacroContext<'a> {
-    /// The name of the struct on which the `#[derive(Patchable)]` macro is applied.
+    /// The name of the struct on which the derive macro is applied.
     struct_name: &'a Ident,
     /// The generics definition of the target struct.
     generics: &'a Generics,
@@ -35,13 +35,13 @@ pub(crate) struct MacroContext<'a> {
     /// Mapping from preserved type to its usage flag.
     preserved_types: HashMap<&'a Ident, TypeUsage>,
     /// The list of actions to perform for each field when generating the `patch` method and the
-    /// state struct.
+    /// patch struct.
     ///
     /// This determines whether a field is copied directly (`Keep`) or recursively patched
     /// (`Patch`).
     field_actions: Vec<FieldAction<'a>>,
-    /// The name of the generated companion state struct (e.g., `MyStructState`).
-    state_struct_name: Ident,
+    /// The name of the generated companion patch struct (e.g., `MyStructPatch`).
+    patch_struct_name: Ident,
     crate_path: TokenStream2,
 }
 
@@ -50,7 +50,7 @@ impl<'a> MacroContext<'a> {
         let Data::Struct(DataStruct { fields, .. }) = &input.data else {
             return Err(syn::Error::new_spanned(
                 input,
-                "This `Patchable` derive macro can only be applied on structs",
+                "This derive macro can only be applied on structs",
             ));
         };
 
@@ -62,17 +62,15 @@ impl<'a> MacroContext<'a> {
         {
             return Err(syn::Error::new_spanned(
                 &input.generics,
-                "`Patchable` does not support borrowed fields",
+                "Patch derives do not support borrowed fields",
             ));
         }
 
         let mut preserved_types: HashMap<&Ident, TypeUsage> = HashMap::new();
         let mut field_actions = vec![];
 
-        let stateful_fields: Vec<&Field> = fields
-            .iter()
-            .filter(|f| !has_serde_skip_attr(f) && !is_phantom_data(f))
-            .collect();
+        let stateful_fields: Vec<&Field> =
+            fields.iter().filter(|f| !has_serde_skip_attr(f)).collect();
 
         for (index, field) in stateful_fields.iter().enumerate() {
             let member = if let Some(field_name) = field.ident.as_ref() {
@@ -117,22 +115,22 @@ impl<'a> MacroContext<'a> {
             fields,
             preserved_types,
             field_actions,
-            state_struct_name: quote::format_ident!("{}State", &input.ident),
+            patch_struct_name: quote::format_ident!("{}Patch", &input.ident),
             crate_path: use_site_crate_path(),
         })
     }
 
     // ============================================================
     // #[derive(::core::clone::Clone, ::serde::Deserialize)]
-    // struct InputTypeState<T, ...> ...
+    // struct InputTypePatch<T, ...> ...
     // ============================================================
 
-    pub(crate) fn build_state_struct(&self) -> TokenStream2 {
-        let state_generic_params = self.collect_state_generics();
+    pub(crate) fn build_patch_struct(&self) -> TokenStream2 {
+        let patch_generic_params = self.collect_patch_generics();
         // Empty `<>` is legal in Rust, and add or drop the `<>` doesn't affect the
         // definition. For example, `struct A<>(i32)` and `struct A(i32)` have the
         // same HIR.
-        let generic_params = quote! { <#(#state_generic_params),*> };
+        let generic_params = quote! { <#(#patch_generic_params),*> };
 
         let mut bounds = Vec::new();
         for param in self.generics.type_params() {
@@ -147,16 +145,16 @@ impl<'a> MacroContext<'a> {
             quote! { where #(#bounds),* }
         };
 
-        let state_fields = self.generate_state_fields();
+        let patch_fields = self.generate_patch_fields();
         let body = match &self.fields {
-            Fields::Named(_) => quote! { #generic_params #where_clause { #(#state_fields),* } },
-            Fields::Unnamed(_) => quote! { #generic_params #where_clause ( #(#state_fields),* ); },
+            Fields::Named(_) => quote! { #generic_params #where_clause { #(#patch_fields),* } },
+            Fields::Unnamed(_) => quote! { #generic_params #where_clause ( #(#patch_fields),* ); },
             Fields::Unit => quote! {;},
         };
-        let state_name = &self.state_struct_name;
+        let patch_name = &self.patch_struct_name;
         quote! {
             #[derive(::core::clone::Clone, ::serde::Deserialize)]
-            pub struct #state_name #body
+            pub struct #patch_name #body
         }
     }
 
@@ -166,25 +164,45 @@ impl<'a> MacroContext<'a> {
 
     pub(crate) fn build_patchable_trait_impl(&self) -> TokenStream2 {
         let crate_root = &self.crate_path;
+        let fully_qualified_trait = quote! { #crate_root :: Patchable };
         let (impl_generics, type_generics, _) = self.generics.split_for_impl();
-        let where_clause = self.build_bounds();
+        let where_clause = self.build_bounded_types(&fully_qualified_trait);
         let assoc_type_decl = self.build_associate_type_declaration();
 
-        let input_struct_name = &self.struct_name;
+        let input_struct_name = self.struct_name;
 
-        let patch_param_name = if self.field_actions.is_empty() {
-            quote! { _state }
-        } else {
-            quote! { state }
-        };
-
-        let patch_method_body = self.generate_patch_method_body();
         quote! {
             impl #impl_generics #crate_root :: Patchable
                 for #input_struct_name #type_generics
             #where_clause {
                 #assoc_type_decl
+            }
+        }
+    }
 
+    // ============================================================
+    // impl<T, ...> Patch for OriginalStruct<T, ...
+    // ============================================================
+
+    pub(crate) fn build_patch_trait_impl(&self) -> TokenStream2 {
+        let crate_root = &self.crate_path;
+        let fully_qualified_trait = quote! { #crate_root :: Patch };
+        let (impl_generics, type_generics, _) = self.generics.split_for_impl();
+        let where_clause = self.build_bounded_types(&fully_qualified_trait);
+
+        let input_struct_name = self.struct_name;
+
+        let patch_param_name = if self.field_actions.is_empty() {
+            quote! { _patch }
+        } else {
+            quote! { patch }
+        };
+
+        let patch_method_body = self.generate_patch_method_body();
+        quote! {
+            impl #impl_generics #fully_qualified_trait
+                for #input_struct_name #type_generics
+            #where_clause {
                 #[inline(always)]
                 fn patch(&mut self, #patch_param_name: Self::Patch) {
                     #patch_method_body
@@ -193,7 +211,7 @@ impl<'a> MacroContext<'a> {
         }
     }
 
-    fn generate_state_fields(&self) -> Vec<TokenStream2> {
+    fn generate_patch_fields(&self) -> Vec<TokenStream2> {
         self.field_actions
             .iter()
             .map(|action| match action {
@@ -233,12 +251,12 @@ impl<'a> MacroContext<'a> {
         let statements = self.field_actions.iter().map(|action| match action {
             FieldAction::Keep { member, .. } => {
                 quote! {
-                    self.#member = state.#member;
+                    self.#member = patch.#member;
                 }
             }
             FieldAction::Patch { member, .. } => {
                 quote! {
-                    self.#member.patch(state.#member);
+                    self.#member.patch(patch.#member);
                 }
             }
         });
@@ -248,7 +266,7 @@ impl<'a> MacroContext<'a> {
         }
     }
 
-    fn collect_state_generics(&self) -> Vec<Ident> {
+    fn collect_patch_generics(&self) -> Vec<Ident> {
         let mut generics = Vec::new();
         for param in self.generics.type_params() {
             if self.preserved_types.contains_key(&param.ident) {
@@ -258,17 +276,16 @@ impl<'a> MacroContext<'a> {
         generics
     }
 
-    fn build_bounds(&self) -> TokenStream2 {
-        let mut bounds = Vec::new();
+    fn build_bounded_types(&self, bound: &TokenStream2) -> TokenStream2 {
+        let mut bounded_types = Vec::new();
         for param in self.generics.type_params() {
             let t = &param.ident;
             match self.preserved_types.get(t) {
                 Some(TypeUsage::Patchable) => {
-                    let crate_root = &self.crate_path;
-                    bounds.push(quote! { #t: #crate_root :: Patchable + ::core::clone::Clone });
+                    bounded_types.push(quote! { #t: #bound + ::core::clone::Clone });
                 }
                 Some(TypeUsage::NotPatchable) => {
-                    bounds.push(quote! { #t: ::core::clone::Clone });
+                    bounded_types.push(quote! { #t: ::core::clone::Clone });
                 }
                 None => {}
             }
@@ -282,11 +299,11 @@ impl<'a> MacroContext<'a> {
             };
             quote! {
                 #normalized_input_where_clause
-                #(#bounds),*
+                #(#bounded_types),*
             }
-        } else if !bounds.is_empty() {
+        } else if !bounded_types.is_empty() {
             quote! {
-                where #(#bounds),*
+                where #(#bounded_types),*
             }
         } else {
             quote! {}
@@ -294,7 +311,7 @@ impl<'a> MacroContext<'a> {
     }
 
     // ============================================================
-    // type Patch = MyState<T, U, ...>
+    // type Patch = MyPatch<T, U, ...>
     // ============================================================
 
     fn build_associate_type_declaration(&self) -> TokenStream2 {
@@ -305,7 +322,7 @@ impl<'a> MacroContext<'a> {
                 args.push(quote! { #t });
             }
         }
-        let state_name = &self.state_struct_name;
+        let state_name = &self.patch_struct_name;
         quote! {
             type Patch = #state_name <#(#args),*>;
         }
@@ -372,14 +389,6 @@ fn has_serde_skip_attr(field: &Field) -> bool {
                 .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
                 .is_ok_and(need_skip)
     })
-}
-
-fn is_phantom_data(field: &Field) -> bool {
-    matches!(
-        &field.ty,
-        Type::Path(p)
-        if p.path.segments.first().is_some_and(|s| s.ident == "PhantomData")
-    )
 }
 
 struct SimpleTypeCollector<'a> {

--- a/patchable-macro/src/lib.rs
+++ b/patchable-macro/src/lib.rs
@@ -1,10 +1,8 @@
 //! # Patchable Macro
 //!
-//! Procedural macro for the `patchable` crate.
+//! Procedural macros for the `patchable` crate: `Patchable` and `Patch` derives.
 //!
-//! This crate contains the `Patchable` derive macro, which generates:
-//! 1. A companion "Patch" struct (e.g., `MyStructPatch`).
-//! 2. An implementation of the `Patchable` trait for the original struct.
+//! See `context` for details on the generated patch struct and trait implementations.
 
 use proc_macro::TokenStream;
 
@@ -14,18 +12,38 @@ use syn::{self, DeriveInput};
 mod context;
 
 #[proc_macro_derive(Patchable, attributes(patchable))]
-pub fn derive_state_and_patchable_impl(input: TokenStream) -> TokenStream {
+pub fn derive_patchable(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse_macro_input!(input as DeriveInput);
     match context::MacroContext::new(&input) {
         Ok(ctx) => {
-            let state_struct_def = ctx.build_state_struct();
+            let patch_struct_def = ctx.build_patch_struct();
             let patchable_trait_impl = ctx.build_patchable_trait_impl();
 
             quote! {
                 const _: () = {
-                    #state_struct_def
+                    #[automatically_derived]
+                    #patch_struct_def
                     #[automatically_derived]
                     #patchable_trait_impl
+                };
+            }
+            .into()
+        }
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_derive(Patch, attributes(patchable))]
+pub fn derive_patch(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = syn::parse_macro_input!(input as DeriveInput);
+    match context::MacroContext::new(&input) {
+        Ok(ctx) => {
+            let patch_trait_impl = ctx.build_patch_trait_impl();
+
+            quote! {
+                const _: () = {
+                    #[automatically_derived]
+                    #patch_trait_impl
                 };
             }
             .into()


### PR DESCRIPTION
Refactor the trait hierarchy to separate the definition of a patch from its application. This allows for more flexible implementations and clearer bounds for types that can be patched versus the patches themselves.

- Restrict `Patchable` to define the associated `Patch` type.
- Introduce `Patch` as a subtrait of `Patchable` to house the `patch` method.
- Rebase `TryPatch` as a subtrait of `Patchable` for consistency.