### PR TITLE
feat: add Cargo feature `impl_from`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,5 +26,8 @@ jobs:
       - name: Run clippy
         run: cargo clippy --verbose
 
-      - name: Run tests
-        run: cargo test --verbose
+      - name: Run tests without feature impl_from
+        run: cargo test --verbose --package patchable
+
+      - name: cargo test with feature impl_from
+        run: cargo test --verbose --package patchable --features impl_from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `impl_from` feature to enable deriving `From<Struct>` for `StructPatch`
+
 ## [0.5.0] - 2026-01-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The provided derive macros handle the heavy lifting:
    - Include **simple fields** directly.
    - Include **complex fields**, which have their own patch types, indirectly by including their patches.
 
-   When `#[derive(Patchable)]` is used, a `From<Struct>` for `StructPatch` will be generated, too.
+   When `#[derive(Patchable)]` is used, a `From<Struct>` for `StructPatch` can be generated
+   by enabling the `impl_from` feature.
 
 2. **Correct Patch Behavior**: The macro generates `Patch` implementations and
    correct `patch` methods based on the rules in item 1.
@@ -68,6 +69,7 @@ The provided derive macros handle the heavy lifting:
 - **Smart Exclusion**: Respects `#[serde(skip)]` and `#[serde(skip_serializing)]`, and `PhantomData` to keep patches lean.
 - **Serde Integration**: Generated patch types automatically implement `serde::Deserialize` and `Clone`
 - **Generic Support**: Full support for generic types with automatic trait bound inference
+- **Optional `From` Derive**: Enable `From<Struct>` for `StructPatch` with the `impl_from` feature
 - **Zero Runtime Overhead**: All code generation happens at compile time
 
 ## Use Cases
@@ -87,6 +89,13 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 patchable = "0.5.0" # You can use the latest version
+```
+
+Enable `From<Struct>` generation:
+
+```toml
+[dependencies]
+patchable = { version = "0.5.0", features = ["impl_from"] }
 ```
 
 ## Usage

--- a/patchable-macro/Cargo.toml
+++ b/patchable-macro/Cargo.toml
@@ -13,6 +13,9 @@ readme.workspace = true
 [lib]
 proc-macro = true
 
+[features]
+impl_from = []
+
 [dependencies]
 proc-macro2.workspace = true
 proc-macro-crate.workspace = true

--- a/patchable-macro/src/lib.rs
+++ b/patchable-macro/src/lib.rs
@@ -17,7 +17,13 @@ pub fn derive_patchable(input: TokenStream) -> TokenStream {
     derive_with(input, |ctx| {
         let patch_struct_def = ctx.build_patch_struct();
         let patchable_trait_impl = ctx.build_patchable_trait_impl();
-        let from_struct_impl = ctx.build_from_trait_impl();
+        let from_struct_impl = cfg!(feature = "impl_from").then(|| {
+            let from_struct_impl = ctx.build_from_trait_impl();
+            quote! {
+                #[automatically_derived]
+                #from_struct_impl
+            }
+        });
 
         quote! {
             const _: () = {
@@ -25,7 +31,6 @@ pub fn derive_patchable(input: TokenStream) -> TokenStream {
                 #patch_struct_def
                 #[automatically_derived]
                 #patchable_trait_impl
-                #[automatically_derived]
                 #from_struct_impl
             };
         }

--- a/patchable/Cargo.toml
+++ b/patchable/Cargo.toml
@@ -19,5 +19,8 @@ serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
 
+[features]
+impl_from = ["patchable-macro/impl_from"]
+
 [dev-dependencies]
 thiserror.workspace = true

--- a/patchable/src/lib.rs
+++ b/patchable/src/lib.rs
@@ -34,6 +34,9 @@ pub use patchable_macro::{Patch, Patchable};
 /// //vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 /// // If we derive `Patchable` and `Patch` for `Accumulator`, the following `AccumulatorPatch`
 /// // plus `Patchable`/`Patch` implementations can be generated automatically.
+/// //
+/// // When deriving `Patchable`, the `From<Accumulator>` implementation is also generated when the
+/// // `impl_from` feature is enabled.
 ///
 /// #[derive(Clone, Deserialize)]
 /// pub struct AccumulatorPatch<T> {
@@ -251,11 +254,13 @@ pub(crate) mod test {
         assert_eq!(s.val, 20);
     }
 
+    #[allow(dead_code)]
     #[derive(Clone, Debug, Serialize, Patchable, Patch, PartialEq)]
     struct Inner {
         value: i32,
     }
 
+    #[allow(dead_code)]
     #[derive(Clone, Debug, Serialize, Patchable, Patch, PartialEq)]
     struct Outer<InnerType> {
         #[patchable]
@@ -263,6 +268,7 @@ pub(crate) mod test {
         extra: u32,
     }
 
+    #[cfg(feature = "impl_from")]
     #[test]
     fn test_from_struct_to_patch() {
         let original = Outer {


### PR DESCRIPTION
When the `impl_from` feature is enabled, `#[derive(Patchable)]` also derives an implementation of `From<Struct>`.