### PR TITLE
docs(readme): archive repository and point to recallable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# ⚠️ Archived: Project Moved to `recallable`
+
+This repository is no longer maintained and has been archived for historical
+reference. Active development by the original author continues under the name
+[**`recallable`**](https://github.com/ShapelessCat/recallable).
+
+**Why the name change?** The term `patchable` typically implies a patch, delta,
+or partial update pattern. Since this project is actually built around the
+Memento design pattern for state management, the name `recallable` was chosen to
+accurately reflect its core architecture. The author may unarchive this
+repository at a later date to implement a real patch, delta, or partial update
+pattern.
+
+Please visit [**`recallable`**](https://github.com/ShapelessCat/recallable) for
+ongoing development, updates, and issues.
+
 # Patchable
 
 [![CI](https://github.com/ShapelessCat/patchable/actions/workflows/ci.yaml/badge.svg)](https://github.com/ShapelessCat/patchable/actions/workflows/ci.yaml)


### PR DESCRIPTION
- Adds an archive notice to the top of the README.

- Explains the transition from `patchable` to `recallable` to better reflect the underlying Memento design pattern.

- Notes that this repository may be unarchived later for a true patch/delta implementation.